### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wondershaper (1.1a-10) UNRELEASED; urgency=medium
+
+  * Apply multi-arch hints.
+    + wondershaper: Add Multi-Arch: foreign.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 28 Oct 2020 14:43:56 -0000
+
 wondershaper (1.1a-9) unstable; urgency=medium
 
   * control:

--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,7 @@ Vcs-Git: https://github.com/leggewie-DM/wondershaper.git
 Package: wondershaper
 Architecture: all
 Depends: iproute2|iproute,${misc:Depends}
+Multi-Arch: foreign
 Description: Easy to use traffic shaping script
  An easy to use traffic shaping script that provides these improvements:
   * Low latency for interactive traffic (and pings) at all times


### PR DESCRIPTION
Apply hints suggested by the multi-arch hinter.

* wondershaper: Add Multi-Arch: foreign. This fixes: wondershaper could be marked Multi-Arch: foreign. ([ma-foreign](https://wiki.debian.org/MultiArch/Hints#ma-foreign))

These changes were suggested on https://wiki.debian.org/MultiArch/Hints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/multiarch-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/wondershaper/87bfc4b8-0c77-4f27-af89-b16eeac3a906.


## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* {+Multi-Arch: foreign+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/87bfc4b8-0c77-4f27-af89-b16eeac3a906/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/87bfc4b8-0c77-4f27-af89-b16eeac3a906/diffoscope)).
