### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,7 @@ Vcs-Git: https://github.com/leggewie-DM/wondershaper.git
 Package: wondershaper
 Architecture: all
 Depends: iproute2|iproute,${misc:Depends}
+Multi-Arch: foreign
 Description: Easy to use traffic shaping script
  An easy to use traffic shaping script that provides these improvements:
   * Low latency for interactive traffic (and pings) at all times


### PR DESCRIPTION


Apply hints suggested by the multi-arch hinter.



These changes were suggested on https://wiki.debian.org/MultiArch/Hints.

Note that in some cases, these multi-arch hints may trigger lintian warnings
until the dependencies of the package support multi-arch. This is expected,
see [https://janitor.debian.net/multiarch-fixes#why-does-lintian-warn](the FAQ) for details.



This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/multiarch-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/wondershaper/e5d3b837-f8c8-4641-b6a9-f5a5ef37d315.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* {+Multi-Arch: foreign+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/e5d3b837-f8c8-4641-b6a9-f5a5ef37d315/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/e5d3b837-f8c8-4641-b6a9-f5a5ef37d315/diffoscope)).
